### PR TITLE
Fix for the Debugging URL's being incorrect if you are on a path that is 'admin'

### DIFF
--- a/src/FilamentDebugger.php
+++ b/src/FilamentDebugger.php
@@ -35,7 +35,7 @@ class FilamentDebugger extends Page
             ->label('Telescope')
             ->sort(1)
             ->url(
-                config('telescope.domain').config('telescope.path')
+                '/'.config('telescope.domain').config('telescope.path')
             )
             ->openUrlInNewTab();
     }
@@ -48,7 +48,7 @@ class FilamentDebugger extends Page
             ->label('Horizon')
             ->sort(2)
             ->url(
-                config('horizon.domain').config('horizon.path')
+                '/'.config('horizon.domain').config('horizon.path')
             )
             ->openUrlInNewTab();
     }


### PR DESCRIPTION
Fix for the URL being incorrect if you are on '/admin'
Fixed by adding a forward slash to the URL to avoid the 404 error. 