### PR TITLE
telescope and horizon url fix's

### DIFF
--- a/src/FilamentDebugger.php
+++ b/src/FilamentDebugger.php
@@ -35,7 +35,7 @@ class FilamentDebugger extends Page
             ->label('Telescope')
             ->sort(1)
             ->url(
-                '/'.config('telescope.domain').config('telescope.path')
+                config('telescope.domain').'/'.config('telescope.path')
             )
             ->openUrlInNewTab();
     }
@@ -48,7 +48,7 @@ class FilamentDebugger extends Page
             ->label('Horizon')
             ->sort(2)
             ->url(
-                '/'.config('horizon.domain').config('horizon.path')
+                config('horizon.domain').'/'.config('horizon.path')
             )
             ->openUrlInNewTab();
     }


### PR DESCRIPTION
For Eg: http://tickets.admin.test/telescope/requests

`config('telescope.domain').'/'.config('telescope.path')`