### PR TITLE
Pull URL from config

### DIFF
--- a/config/filament-debugger.php
+++ b/config/filament-debugger.php
@@ -14,4 +14,9 @@ return [
     ],
 
     'group' => 'Debugger',
+
+    'url' => [
+        'horizon' => env('HORIZON_PATH', 'horizon'),
+        'telescope' => env('TELESCOPE_PATH', 'telescope'),
+    ],
 ];

--- a/src/Traits/HasDebuggers.php
+++ b/src/Traits/HasDebuggers.php
@@ -20,7 +20,7 @@ trait HasDebuggers
         return NavigationItem::make()
             ->visible($this->authorized(config('filament-debugger.permissions.telescope')))
             ->group(config('filament-debugger.group'))
-            ->url(url: url('telescope'), shouldOpenInNewTab: true)
+            ->url(url: url()->to(config('filament-debugger.url.telescope')), shouldOpenInNewTab: true)
             ->icon('heroicon-o-sparkles')
             ->label('Telescope');
     }
@@ -31,7 +31,7 @@ trait HasDebuggers
             ->visible($this->authorized(config('filament-debugger.permissions.horizon')))
             ->group(config('filament-debugger.group'))
             ->icon('heroicon-o-globe-europe-africa')
-            ->url(url: url('horizon'), shouldOpenInNewTab: true)
+            ->url(url: url()->to(config('filament-debugger.url.horizon')), shouldOpenInNewTab: true)
             ->label('Horizon');
     }
 }


### PR DESCRIPTION
I had to use a different url to avoid issues with my current project. Here's my take to pull the URL used by the plugin from the .env

It still use the same URL by default, only using them if they're present in the .env

-[filament-debugger.php] Added URL in the config file pulling from the .env and setting a string if it isnt't found.
-[HasDebuggers.php] We use this config in the url of the Trait.
