### PR TITLE
Update default URLs to use named routes

### DIFF
--- a/src/Traits/HasHorizon.php
+++ b/src/Traits/HasHorizon.php
@@ -62,7 +62,7 @@ trait HasHorizon
 
     public function getHorizonUrl(): string
     {
-        return $this->horizonUrl ?? url('horizon');
+        return $this->horizonUrl ?? (Route::has('horizon.index') ? route('horizon.index') : url('horizon'));
     }
 
     public function getHorizonLabel(): string

--- a/src/Traits/HasPulse.php
+++ b/src/Traits/HasPulse.php
@@ -57,7 +57,7 @@ trait HasPulse
 
     public function getPulseUrl(): string
     {
-        return $this->pulseUrl ?? url('pulse');
+        return $this->pulseUrl ?? (Route::has('pulse') ? route('pulse') : url('pulse'));
     }
 
     public function getPulseOpenInNewTab(): bool

--- a/src/Traits/HasTelescope.php
+++ b/src/Traits/HasTelescope.php
@@ -57,7 +57,7 @@ trait HasTelescope
 
     public function getTelescopeUrl(): string
     {
-        return $this->telescopeUrl ?? url('telescope');
+        return $this->telescopeUrl ?? (Route::has('telescope') ? route('telescope') : url('telescope'));
     }
 
     public function getTelescopeOpenInNewTab(): bool


### PR DESCRIPTION
Telescope, Horizon and Pulse all use named routes in their configuration however the traits here use static URLs.  This PR updates the traits to use the named routes instead so that if they are changed in their config files, no additional configuration is necessary for this plugin.