### PR TITLE
feat: Upgrade to Filament v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "filament/filament": "^4.0",
+        "filament/filament": "^5.0",
         "illuminate/contracts": "^11.0|^12.0",
         "spatie/laravel-package-tools": "^1.16.0"
     },


### PR DESCRIPTION
## Summary

This PR adds support for Filament v5 by updating the composer.json dependency constraint.

## Changes

- Updated `filament/filament` requirement from `^4.0` to `^5.0`

## Breaking Change

This is a **BREAKING CHANGE** as it requires Filament v5. Projects still using Filament v4 should continue using `filament-debugger` v4.x.

## Rationale

According to Filament's upgrade documentation, v5 is primarily a Livewire v4 compatibility release with minimal breaking changes to the package itself. The package code does not require any modifications to work with Filament v5.

## Related Issue

Fixes #51

## Testing

The package has no version-specific code, so the change is limited to the dependency constraint. Projects using Filament v5 will now be able to install this package.