### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "filament/filament": "^5.0",
-        "illuminate/contracts": "^11.0|^12.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.16.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     },
     "require-dev": {
         "laravel/pint": "^1.17",
-        "nunomaduro/collision": "^8.0",
-        "orchestra/testbench": "^9.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0",
-        "pestphp/pest-plugin-livewire": "^3.0",
-        "phpunit/phpunit": "^11.0"
+        "nunomaduro/collision": "^8.0|^9.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+        "pestphp/pest-plugin-livewire": "^3.0|^4.0",
+        "phpunit/phpunit": "^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary

- Widens `illuminate/contracts` constraint from `^11.0|^12.0` to `^11.0|^12.0|^13.0`
- No source code changes needed — the package has no incompatibilities with Laravel 13

## Context

Laravel 13 was released and this package's version constraint on `illuminate/contracts` is the only blocker preventing installation on Laravel 13 projects.